### PR TITLE
Remove and ignore any pkg lock files for legacy repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ typings/
 
 # next.js build output
 .next
+
+# Commit no lockfiles for legacy repos
+package-lock.json
+yarn.lock


### PR DESCRIPTION
This set of pull requests was the supervised result of:
```
git rm --ignore-unmatch package-lock.json yarn.lock
echo '# Commit no lockfiles for legacy repos\npackage-lock.json\nyarn.lock' >> .gitignore
```

This is to ensure that for any of our legacy repos, we never, intentionally or accidentally, commit a lockfile for either Yarn or NPM to the git repo.

Only repos that didn't have both kinds of lock files ignored had branches created and PRs made.